### PR TITLE
chore: Upgrade python requirements.

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,23 +4,21 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.6.0
     # via
     #   tox
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.4.0
+platformdirs==2.5.1
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 six==1.16.0
     # via
@@ -28,11 +26,11 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.4
+tox==3.24.5
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-virtualenv==20.10.0
+virtualenv==20.13.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,10 +12,6 @@ babel==2.9.1
     # via
     #   -r requirements/doc.txt
     #   sphinx
-backports.entry-points-selectable==1.1.1
-    # via
-    #   -r requirements/ci.txt
-    #   virtualenv
 bleach==4.1.0
     # via
     #   -r requirements/doc.txt
@@ -24,11 +20,11 @@ certifi==2021.10.8
     # via
     #   -r requirements/doc.txt
     #   requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via
     #   -r requirements/doc.txt
     #   requests
-click==8.0.3
+click==8.0.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -47,7 +43,7 @@ docutils==0.17.1
     #   sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.txt
-filelock==3.4.0
+filelock==3.6.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -60,11 +56,15 @@ imagesize==1.3.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
+importlib-metadata==4.11.2
+    # via
+    #   -r requirements/doc.txt
+    #   sphinx
 jinja2==3.0.3
     # via
     #   -r requirements/doc.txt
     #   sphinx
-markupsafe==2.0.1
+markupsafe==2.1.0
     # via
     #   -r requirements/doc.txt
     #   jinja2
@@ -75,7 +75,7 @@ packaging==21.3
     #   bleach
     #   sphinx
     #   tox
-pbr==5.8.0
+pbr==5.8.1
     # via
     #   -r requirements/doc.txt
     #   stevedore
@@ -83,9 +83,9 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.txt
-platformdirs==2.4.0
+platformdirs==2.5.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -97,13 +97,13 @@ py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   -r requirements/doc.txt
     #   doc8
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
@@ -112,13 +112,13 @@ pytz==2021.3
     # via
     #   -r requirements/doc.txt
     #   babel
-readme-renderer==31.0
+readme-renderer==33.0
     # via -r requirements/doc.txt
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements/doc.txt
     #   sphinx
-restructuredtext-lint==1.3.2
+restructuredtext-lint==1.4.0
     # via
     #   -r requirements/doc.txt
     #   doc8
@@ -134,7 +134,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
-sphinx==4.3.1
+sphinx==4.4.0
     # via
     #   -r requirements/doc.txt
     #   edx-sphinx-theme
@@ -170,21 +170,21 @@ toml==0.10.2
     # via
     #   -r requirements/ci.txt
     #   tox
-tomli==1.2.2
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   pep517
-tox==3.24.4
+tox==3.24.5
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -r requirements/doc.txt
     #   requests
-virtualenv==20.10.0
+virtualenv==20.13.3
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -192,10 +192,14 @@ webencodings==0.5.1
     # via
     #   -r requirements/doc.txt
     #   bleach
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+zipp==3.7.0
+    # via
+    #   -r requirements/doc.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ bleach==4.1.0
     # via readme-renderer
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via requests
 doc8==0.10.1
     # via -r requirements/doc.in
@@ -28,30 +28,32 @@ idna==3.3
     # via requests
 imagesize==1.3.0
     # via sphinx
+importlib-metadata==4.11.2
+    # via sphinx
 jinja2==3.0.3
     # via sphinx
-markupsafe==2.0.1
+markupsafe==2.1.0
     # via jinja2
 packaging==21.3
     # via
     #   bleach
     #   sphinx
-pbr==5.8.0
+pbr==5.8.1
     # via stevedore
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   doc8
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pytz==2021.3
     # via babel
-readme-renderer==31.0
+readme-renderer==33.0
     # via -r requirements/doc.in
-requests==2.26.0
+requests==2.27.1
     # via sphinx
-restructuredtext-lint==1.3.2
+restructuredtext-lint==1.4.0
     # via doc8
 six==1.16.0
     # via
@@ -59,7 +61,7 @@ six==1.16.0
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.1
+sphinx==4.4.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -77,10 +79,9 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 stevedore==3.5.0
     # via doc8
-urllib3==1.26.7
+urllib3==1.26.8
     # via requests
 webencodings==0.5.1
     # via bleach
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.7.0
+    # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.0.4
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.in
-tomli==1.2.2
+tomli==2.0.1
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
We got in a situation where the newest version of pip breaks the pinned
version of pip-tools from running correctly.

https://github.com/jazzband/pip-tools/issues/1558

The issue is fixed in newer version of pip-tools so the only way to
resolve this is to first manually upgrade pip-tools and re-compile the
pip-tools.txt requirements file and then run `make upgrade`.
